### PR TITLE
Use Neovim's builtin `vim.lsp.config` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Here's an example for the [lazy.nvim](https://github.com/folke/lazy.nvim) plugin
 {
     "rabuu/polarity.nvim",
     ft = "polarity",
-    dependencies = { "neovim/nvim-lspconfig" },
 
     -- This is the default configuration
     opts = {
@@ -29,3 +28,21 @@ Here's an example for the [lazy.nvim](https://github.com/folke/lazy.nvim) plugin
     },
 }
 ```
+
+## LSP configuration
+This plugin uses Neovim's builtin `vim.lsp.config` API. Therefore, version 0.11+ is needed.
+
+To use the old `nvim-lspconfig`, you can target the `legacy-lsp` branch.
+<details>
+<summary>lazy.nvim example</summary>
+<br>
+
+```lua
+{
+    "rabuu/polarity.nvim",
+    ft = "polarity",
+    branch = "legacy-lsp",
+}
+```
+
+</details>

--- a/lua/polarity/lsp.lua
+++ b/lua/polarity/lsp.lua
@@ -8,14 +8,14 @@ function M.setup(opts)
 		capabilities = vim.tbl_deep_extend("force", capabilities, require("blink.cmp").get_lsp_capabilities({}, false))
 	end
 
-	configs.polarity = {
-		default_config = {
-			filetypes = { "polarity" },
-			capabilities = capabilities,
-		}
+	local default_config = {
+		filetypes = { "polarity" },
+		capabilities = capabilities,
 	}
 
-	vim.lsp.config("polarity", opts.server)
+	local lsp_config = vim.tbl_deep_extend("force", default_config, opts.server)
+
+	vim.lsp.config("polarity", lsp_config)
 end
 
 return M

--- a/lua/polarity/lsp.lua
+++ b/lua/polarity/lsp.lua
@@ -16,6 +16,7 @@ function M.setup(opts)
 	local lsp_config = vim.tbl_deep_extend("force", default_config, opts.server)
 
 	vim.lsp.config("polarity", lsp_config)
+	vim.lsp.enable("polarity")
 end
 
 return M

--- a/lua/polarity/lsp.lua
+++ b/lua/polarity/lsp.lua
@@ -1,9 +1,6 @@
 local M = {}
 
 function M.setup(opts)
-	local lspconfig = require("lspconfig")
-	local configs = require("lspconfig.configs")
-
 	local capabilities = vim.lsp.protocol.make_client_capabilities()
 	if pcall(require, "cmp_nvim_lsp") then
 		capabilities = vim.tbl_deep_extend("force", capabilities, require("cmp_nvim_lsp").default_capabilities())
@@ -14,15 +11,11 @@ function M.setup(opts)
 	configs.polarity = {
 		default_config = {
 			filetypes = { "polarity" },
-			root_dir = function(fname)
-				-- return lspconfig.util.find_git_ancestor(fname) or vim.fn.getcwd()
-				return vim.fn.getcwd()
-			end,
 			capabilities = capabilities,
 		}
 	}
 
-	lspconfig.polarity.setup(opts.server)
+	vim.lsp.config("polarity", opts.server)
 end
 
 return M


### PR DESCRIPTION
Since Neovim 0.11, the [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) framework is deprecated in favor of the new `vim.lsp.config` API.